### PR TITLE
fix(auth,types): align dev login flow and rdflib typing

### DIFF
--- a/dev/index.js
+++ b/dev/index.js
@@ -19,12 +19,13 @@ const chatPaneContainer = document.getElementById('chatPane')
 loginBanner.appendChild(UI.login.loginStatusBox(document, null, {}))
 
 async function finishLogin () {
-  await authSession.handleIncomingRedirect()
+  await authn.checkUser()
   // Clear fetch auth metadata cached before login (often read-only WAC-Allow from anonymous requests).
   // Without this, updater.editable() can stay false even when the user can PATCH after authentication.
   store.updater.flagAuthorizationMetadata(store)
   const session = authSession
-  if (session.info.isLoggedIn) {
+  const isLoggedIn = session?.info?.isLoggedIn ?? session?.isActive ?? Boolean(session?.webId)
+  if (isLoggedIn) {
     const me = authn.currentUser()
     // Update the page with the status.
     webId.innerHTML = 'Logged in as: ' + me.uri

--- a/src/create.ts
+++ b/src/create.ts
@@ -107,7 +107,7 @@ async function addToPrivateTypeIndex (chatThing, me) {
     st(reg, ns.rdf('type'), ns.solid('TypeRegistration'), privateTypeIndex.doc()),
     st(reg, ns.solid('forClass'), ns.meeting('LongChat'), privateTypeIndex.doc()),
     st(reg, ns.solid('instance'), chatThing, privateTypeIndex.doc())
-  ]
+  ] as any
   await new Promise<void>((resolve, reject) => {
     store.updater.update([], ins, function (_uri, ok, errm) {
       if (!ok) {
@@ -119,7 +119,7 @@ async function addToPrivateTypeIndex (chatThing, me) {
   })
 }
 
-export async function findChat (invitee: NamedNode) {
+export async function findChat (invitee: NamedNode): Promise<{ me: any, chatContainer: NamedNode, exists: boolean }> {
   const me = await getMe()
   const podRoot = await getPodRoot(me)
   const chatContainer = determineChatContainer(invitee, podRoot)


### PR DESCRIPTION
Use authn.checkUser and compatibility-safe session checks in dev login bootstrap.\nStabilize create.ts typing boundaries to avoid cross-package rdflib identity type errors.